### PR TITLE
Enhance the way to use the package

### DIFF
--- a/src/epivizFileParser/__init__.py
+++ b/src/epivizFileParser/__init__.py
@@ -14,3 +14,11 @@ except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
 finally:
     del version, PackageNotFoundError
+
+from .BigWig import BigWig
+from .BigBed import BigBed
+from .GtfParsedFile import GtfParsedFile
+from .GWASBigBedPIP import GWASBigBedPIP
+from .GWASBigBedPval import GWASBigBedPval
+from .S3HDF5File import S3HDF5File
+from .TranscriptTbxFile import TranscriptTbxFile

--- a/tests/test_BigBed.py
+++ b/tests/test_BigBed.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 
-from epivizFileParser.BigBed import BigBed
+from epivizFileParser import BigBed
 
 __author__ = "jkanche, elgaml"
 __copyright__ = "jkanche"

--- a/tests/test_BigWig.py
+++ b/tests/test_BigWig.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 
-from epivizFileParser.BigWig import BigWig
+from epivizFileParser import BigWig
 
 __author__ = "jkanche, elgaml"
 __copyright__ = "jkanche"

--- a/tests/test_BigWig_remote.py
+++ b/tests/test_BigWig_remote.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 
-from epivizFileParser.BigWig import BigWig
+from epivizFileParser import BigWig
 
 __author__ = "jkanche, elgaml"
 __copyright__ = "jkanche"

--- a/tests/test_BigWig_s3.py
+++ b/tests/test_BigWig_s3.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 
-from epivizFileParser.BigWig import BigWig
+from epivizFileParser import BigWig
 
 __author__ = "jkanche, elgaml"
 __copyright__ = "jkanche"

--- a/tests/test_GWASBigBedPIP.py
+++ b/tests/test_GWASBigBedPIP.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 
-from epivizFileParser.GWASBigBedPIP import GWASBigBedPIP
+from epivizFileParser import GWASBigBedPIP
 
 __author__ = "jkanche, elgaml"
 __copyright__ = "jkanche"

--- a/tests/test_GWASBigBedPval.py
+++ b/tests/test_GWASBigBedPval.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 
-from epivizFileParser.GWASBigBedPval import GWASBigBedPval
+from epivizFileParser import GWASBigBedPval
 
 __author__ = "jkanche, elgaml"
 __copyright__ = "jkanche"

--- a/tests/test_GtfParsedFile.py
+++ b/tests/test_GtfParsedFile.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 
-from epivizFileParser.GtfParsedFile import GtfParsedFile
+from epivizFileParser import GtfParsedFile
 
 __author__ = "jkanche, elgaml"
 __copyright__ = "jkanche"

--- a/tests/test_S3HDF5File.py
+++ b/tests/test_S3HDF5File.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 
-from epivizFileParser.S3HDF5File import S3HDF5File
+from epivizFileParser import S3HDF5File
 
 __author__ = "Hany Elgaml"
 __copyright__ = "mit"

--- a/tests/test_TranscriptTbxFile.py
+++ b/tests/test_TranscriptTbxFile.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 
-from epivizFileParser.TranscriptTbxFile import TranscriptTbxFile
+from epivizFileParser import TranscriptTbxFile
 
 __author__ = "jkanche, elgaml"
 __copyright__ = "jkanche"

--- a/tests/test_simplified_bin_rows.py
+++ b/tests/test_simplified_bin_rows.py
@@ -3,7 +3,7 @@ import os
 import pandas as pd
 import json
 import statistics
-from epivizFileParser.BigWig import BigWig
+from epivizFileParser import BigWig
 bb = BigWig("https://obj.umiacs.umd.edu/bigwig-files/39031.bigwig")
 
 @pytest.mark.skip(reason="skip")


### PR DESCRIPTION
Instead of writing:
from epivizFileParser.BigBed import BigBed
Now we can write:
from epivizFileParser import BigWig, BigBed
__init__.py file is fixed and all the test files